### PR TITLE
Update nginx.conf (Issue #1256)

### DIFF
--- a/frontend/confd/templates/nginx.conf
+++ b/frontend/confd/templates/nginx.conf
@@ -122,7 +122,8 @@ http {
 		}
 
 		# Get the hostname from environment here?
-		location /api/v1 {
+		# location /api/v1 {
+		location ~ /api/v(1|2) {
 			proxy_pass http://{{ getenv "BACKEND_HOSTNAME" "shuffle-backend" }}:5001;
 			proxy_buffering off;
 			proxy_http_version 1.1;


### PR DESCRIPTION
Corrects an error whereby workflow run history is visible in the UI when accessing the front end through http but not https. Addresses Issue:  Execution History Not Showing #1256